### PR TITLE
Coords reading fix

### DIFF
--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -80,10 +80,10 @@ def open_sdf_dataset(filename_or_obj, *, drop_variables=None):
             for dim_size, dim_name in zip(value.grid_mid.dims, value.grid_mid.labels):
                 dim_size_lookup[dim_name][dim_size] = f"{dim_name}_{grid_mid_base_name}"
 
-            var_coords = (
+            var_coords = [
                 dim_size_lookup[dim_name][dim_size]
                 for dim_name, dim_size in zip(value.grid.labels, value.dims)
-            )
+            ]
             # TODO: error handling here? other attributes?
             data_attrs = {"units": value.units}
             data_vars[key] = (var_coords, value.data, data_attrs)

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -1,12 +1,12 @@
-from collections import defaultdict
 import os
 import pathlib
-
-from . import sdf
+from collections import defaultdict
 
 import xarray as xr
 from xarray.backends import BackendEntrypoint
 from xarray.core.utils import try_read_magic_number_from_path
+
+from . import sdf
 
 
 def open_sdf_dataset(filename_or_obj, *, drop_variables=None):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,6 +10,15 @@ def test_basic():
     with xr.open_dataset(EXAMPLE_FILES_DIR / "0000.sdf") as df:
         ex_field = "Electric Field/Ex"
         assert ex_field in df
-        x_coord = "X_x_px_deltaf/electron_beam"
+        x_coord = "X_Grid_mid"
         assert x_coord in df[ex_field].coords
         assert df[x_coord].attrs["long_name"] == "X"
+
+
+def test_coords():
+    with xr.open_dataset(EXAMPLE_FILES_DIR / "0010.sdf") as df:
+        px_electron = "dist_fn/x_px/electron"
+        assert px_electron in df
+        x_coord = "Px_x_px/electron"
+        assert x_coord in df[px_electron].coords
+        assert df[x_coord].attrs["long_name"] == "Px"


### PR DESCRIPTION
An error occurred when I loaded in the attached `0011.sdf` file that has four new coordinate attributes; `Px_px_py/Photon`, `Py_px_py/Photon`, `Px_px_py/Photon_mid`, and `Py_px_py/Photon_mid`. 

I believe that the route cause to this problem is the generator expression `var_coords`
```python
var_coords = (
    dim_size_lookup[dim_name][dim_size]
    for dim_name, dim_size in zip(value.grid.labels, value.dims)
)
```
 that gets called lazily on line `98` after the loop that converts SDF variables and meshes to xarray `DataArrays` and `Coordinates`
```python 
ds = xr.Dataset(data_vars, attrs=attrs, coords=coords)
```

This seems to lead to it incorrectly capturing each coordinates `long_name` and array length. It instead opts to try to use the ones set the first time that the function was called which is normally something like `{ "X": 128, "Y": 128 }` when it should be using `{ "Px": 200, "Py": 200 }`. As a remedy to this problem I suggest that we instead opt to utilise list comprehension which is slower but avoids the above issue.