### PR TITLE
Add dask to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requires-python = ">=3.10"
 dependencies = [
   "numpy>=2.0.0",
   "xarray>=2024.1.0",
+  "dask>=2024.7.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Request to add `dask` version `2024.7.1` (latest version) to project otherwise errors are caused when first importing