### PR TITLE
Convert ssh submodule to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "externals/sdf_c"]
 	path = externals/sdf_c
-	url = git@github.com:Warwick-Plasma/SDF_C.git
+	url = https://github.com/Warwick-Plasma/SDF_C.git


### PR DESCRIPTION
When installing the `.gitmodules` through git they should use `https://` links as users cannot clone via `git@` unless they have a public private key setup