### PR TITLE
Jupyter Notebooks support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ parts/
 sdist/
 var/
 wheels/
+wheelhouse/
 share/python-wheels/
 *.egg-info/
 .installed.cfg

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Install from PyPI with:
 pip install sdf-xarray
 ```
 
+> [!NOTE]
+> For use within jupyter notebooks, run this additional command after installation:
+>
+> ```bash
+> pip install "sdf-xarray[jupyter]"
+> ```
+
 or from a local checkout:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,20 @@
 [build-system]
 requires = [
-    "scikit-build-core>=0.3",
-    "setuptools_scm",
-    "numpy>=2.0.0",
-    "cython>=3.0",
+  "scikit-build-core>=0.3",
+  "setuptools_scm",
+  "numpy>=2.0.0",
+  "cython>=3.0",
 ]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "sdf-xarray"
 dynamic = ["version"]
-license = {file = "LICENCE"}
+license = { file = "LICENCE" }
 readme = "README.md"
 authors = [
-    {name = "Peter Hill", email = "peter.hill@york.ac.uk"},
-    {name = "Joel Adams", email = "joel.adams@york.ac.uk"},
+  { name = "Peter Hill", email = "peter.hill@york.ac.uk" },
+  { name = "Joel Adams", email = "joel.adams@york.ac.uk" },
 ]
 requires-python = ">=3.10"
 dependencies = [
@@ -27,18 +27,16 @@ description = "Provides a backend for xarray to read SDF files as created by the
 
 [project.optional-dependencies]
 docs = [
-     "sphinx >= 5.3",
-     "sphinx_autodoc_typehints >= 1.19",
-     "sphinx-book-theme >= 0.4.0rc1",
-     "sphinx-argparse-cli >= 1.10.0",
-     "sphinx-inline-tabs",
+  "sphinx >= 5.3",
+  "sphinx_autodoc_typehints >= 1.19",
+  "sphinx-book-theme >= 0.4.0rc1",
+  "sphinx-argparse-cli >= 1.10.0",
+  "sphinx-inline-tabs",
 ]
-test = [
-      "pytest >= 3.3.0",
-      "dask[complete]",
-]
+test = ["pytest >= 3.3.0", "dask[complete]"]
 lint = ["ruff"]
 build = ["cibuildwheel[uv]"]
+jupyter = ["dask[diagnostics] >= 2024.7.1", "ipykernel>=6.29.5"]
 
 [project.entry-points."xarray.backends"]
 sdf_engine = "sdf_xarray:SDFEntrypoint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,16 +27,16 @@ description = "Provides a backend for xarray to read SDF files as created by the
 
 [project.optional-dependencies]
 docs = [
-  "sphinx >= 5.3",
-  "sphinx_autodoc_typehints >= 1.19",
-  "sphinx-book-theme >= 0.4.0rc1",
-  "sphinx-argparse-cli >= 1.10.0",
+  "sphinx>=5.3",
+  "sphinx_autodoc_typehints>=1.19",
+  "sphinx-book-theme>=0.4.0rc1",
+  "sphinx-argparse-cli>=1.10.0",
   "sphinx-inline-tabs",
 ]
 test = ["pytest >= 3.3.0", "dask[complete]"]
 lint = ["ruff"]
 build = ["cibuildwheel[uv]"]
-jupyter = ["dask[diagnostics] >= 2024.7.1", "ipykernel>=6.29.5"]
+jupyter = ["dask[diagnostics]", "ipykernel>=6.29.5"]
 
 [project.entry-points."xarray.backends"]
 sdf_engine = "sdf_xarray:SDFEntrypoint"


### PR DESCRIPTION
Updates `pyproject.toml` with an optional dependency to support Jupyter notebooks. Also updates README to reduce potential future questions about Jupyter support

Fixes #29 