### PR TITLE
Add time units, long_name, and full_name

### DIFF
--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -421,7 +421,13 @@ class SDFPreprocess:
             )
 
         ds = ds.expand_dims(time=[ds.attrs["time"]])
-
+        ds = ds.assign_coords(
+            time=(
+                "time",
+                [ds.attrs["time"]],
+                {"units": "s", "long_name": "Time", "full_name": "time"},
+            )
+        )
         # Particles' spartial coordinates also evolve in time
         for coord, value in ds.coords.items():
             if value.attrs.get("point_data", False):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -108,6 +108,13 @@ def test_erroring_on_mismatched_jobid_files():
         )
 
 
+def test_time_dim_units():
+    df = xr.open_mfdataset(EXAMPLE_ARRAYS_DIR.glob("*.sdf"), preprocess=SDFPreprocess())
+    assert df["time"].units == "s"
+    assert df["time"].long_name == "Time"
+    assert df["time"].full_name == "time"
+
+
 def test_arrays_with_no_grids():
     with xr.open_dataset(EXAMPLE_ARRAYS_DIR / "0001.sdf") as df:
         laser_phase = "laser_x_min_phase"


### PR DESCRIPTION
Add the following attributes to the time dim
```python
{"units": "s", "long_name": "Time", "full_name": "time"}
```

Tests also updated

Fixes #35 