### PR TITLE
Latex variable name processing

### DIFF
--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -255,9 +255,16 @@ class SDFDataStore(AbstractDataStore):
             suffixes = ["x", "y", "z"]
             for prefix in prefixes:
                 for suffix in suffixes:
-                    affix = f"{prefix}{suffix}"
-                    if affix in variable_name:
-                        return variable_name.replace(affix, f"{prefix}$_{suffix}$")
+                    affix_spaces = f" {prefix}{suffix} "
+                    affix_no_spaces = f" {prefix}{suffix}"
+                    if affix_spaces in variable_name:
+                        return variable_name.replace(
+                            affix_spaces, f" {prefix}$_{suffix} $"
+                        )
+                    elif affix_no_spaces in variable_name:
+                        return variable_name.replace(
+                            affix_no_spaces, f" {prefix}$_{suffix}$"
+                        )
             return variable_name
 
         for key, value in self.ds.grids.items():

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -250,6 +250,16 @@ class SDFDataStore(AbstractDataStore):
             renamed_name = _rename_with_underscore(transformed_name)
             return renamed_name
 
+        def _process_latex_name(variable_name: str) -> str:
+            prefixes = ["E", "B", "J", "P"]
+            suffixes = ["x", "y", "z"]
+            for prefix in prefixes:
+                for suffix in suffixes:
+                    affix = f"{prefix}{suffix}"
+                    if affix in variable_name:
+                        return variable_name.replace(affix, f"{prefix}$_{suffix}$")
+            return variable_name
+
         for key, value in self.ds.grids.items():
             if "cpu" in key.lower():
                 # Had some problems with these variables, so just ignore them for now
@@ -343,7 +353,7 @@ class SDFDataStore(AbstractDataStore):
 
             # TODO: error handling here? other attributes?
             base_name = _rename_with_underscore(key)
-            long_name = base_name.replace("_", " ")
+            long_name = _process_latex_name(base_name.replace("_", " "))
             data_attrs = {
                 "units": value.units,
                 "point_data": value.is_point_data,

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -39,10 +39,9 @@ def _process_latex_name(variable_name: str) -> str:
     suffixes = ["x", "y", "z"]
     for prefix, suffix in product(prefixes, suffixes):
         # Match affix with preceding space and trailing space or end of string
-        # and capture the leading/trailing spaces
-        affix_pattern = rf"(\s+){prefix}{suffix}(\s*|$)"
+        affix_pattern = rf"\b{prefix}{suffix}\b"
         # Insert LaTeX format while preserving spaces
-        replacement = rf"\1${prefix}_{suffix}$\2"
+        replacement = rf"${prefix}_{suffix}$"
         variable_name = re.sub(affix_pattern, replacement, variable_name)
     return variable_name
 

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -256,14 +256,14 @@ class SDFDataStore(AbstractDataStore):
             for prefix in prefixes:
                 for suffix in suffixes:
                     affix_spaces = f" {prefix}{suffix} "
-                    affix_no_spaces = f" {prefix}{suffix}"
+                    affix_no_trailing_space = f" {prefix}{suffix}"
                     if affix_spaces in variable_name:
                         return variable_name.replace(
                             affix_spaces, f" {prefix}$_{suffix} $"
                         )
-                    elif affix_no_spaces in variable_name:
+                    elif affix_no_trailing_space in variable_name:
                         return variable_name.replace(
-                            affix_no_spaces, f" {prefix}$_{suffix}$"
+                            affix_no_trailing_space, f" {prefix}$_{suffix}$"
                         )
             return variable_name
 

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -259,7 +259,7 @@ class SDFDataStore(AbstractDataStore):
                     affix_no_trailing_space = f" {prefix}{suffix}"
                     if affix_spaces in variable_name:
                         return variable_name.replace(
-                            affix_spaces, f" {prefix}$_{suffix} $"
+                            affix_spaces, f" {prefix}$_{suffix}$ "
                         )
                     elif affix_no_trailing_space in variable_name:
                         return variable_name.replace(

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -251,6 +251,17 @@ class SDFDataStore(AbstractDataStore):
             return renamed_name
 
         def _process_latex_name(variable_name: str) -> str:
+            """Converts variable names to LaTeX format where possible
+            using the following rules:
+            - E -> E$_x$
+            - E -> E$_y$
+            - E -> E$_z$
+
+            This repeats for B, J and P. It only changes the variable
+            name if there are spaces around the affix (prefix + suffix)
+            or if there is no trailing space. This is to avoid changing variable
+            names that may contain these affixes as part of the variable name itself.
+            """
             prefixes = ["E", "B", "J", "P"]
             suffixes = ["x", "y", "z"]
             for prefix in prefixes:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -115,6 +115,19 @@ def test_time_dim_units():
     assert df["time"].full_name == "time"
 
 
+def test_latex_rename_variables():
+    df = xr.open_mfdataset(EXAMPLE_ARRAYS_DIR.glob("*.sdf"), preprocess=SDFPreprocess())
+    assert df["Electric_Field_Ex"].attrs["long_name"] == "Electric Field E$_x$"
+    assert df["Electric_Field_Ey"].attrs["long_name"] == "Electric Field E$_y$"
+    assert df["Electric_Field_Ez"].attrs["long_name"] == "Electric Field E$_z$"
+    assert df["Magnetic_Field_Bx"].attrs["long_name"] == "Magnetic Field B$_x$"
+    assert df["Magnetic_Field_By"].attrs["long_name"] == "Magnetic Field B$_y$"
+    assert df["Magnetic_Field_Bz"].attrs["long_name"] == "Magnetic Field B$_z$"
+    assert df["Current_Jx"].attrs["long_name"] == "Current J$_x$"
+    assert df["Current_Jy"].attrs["long_name"] == "Current J$_y$"
+    assert df["Current_Jz"].attrs["long_name"] == "Current J$_z$"
+
+
 def test_arrays_with_no_grids():
     with xr.open_dataset(EXAMPLE_ARRAYS_DIR / "0001.sdf") as df:
         laser_phase = "laser_x_min_phase"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -116,7 +116,11 @@ def test_time_dim_units():
 
 
 def test_latex_rename_variables():
-    df = xr.open_mfdataset(EXAMPLE_ARRAYS_DIR.glob("*.sdf"), preprocess=SDFPreprocess())
+    df = xr.open_mfdataset(
+        EXAMPLE_ARRAYS_DIR.glob("*.sdf"),
+        preprocess=SDFPreprocess(),
+        keep_particles=True,
+    )
     assert df["Electric_Field_Ex"].attrs["long_name"] == "Electric Field E$_x$"
     assert df["Electric_Field_Ey"].attrs["long_name"] == "Electric Field E$_y$"
     assert df["Electric_Field_Ez"].attrs["long_name"] == "Electric Field E$_z$"
@@ -126,6 +130,9 @@ def test_latex_rename_variables():
     assert df["Current_Jx"].attrs["long_name"] == "Current J$_x$"
     assert df["Current_Jy"].attrs["long_name"] == "Current J$_y$"
     assert df["Current_Jz"].attrs["long_name"] == "Current J$_z$"
+    assert df["Particles_Px_Electron"].attrs["long_name"] == "Particles P$_x$ Electron"
+    assert df["Particles_Py_Electron"].attrs["long_name"] == "Particles P$_y$ Electron"
+    assert df["Particles_Pz_Electron"].attrs["long_name"] == "Particles P$_z$ Electron"
 
 
 def test_arrays_with_no_grids():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,7 +3,7 @@ import pathlib
 import pytest
 import xarray as xr
 
-from sdf_xarray import SDFPreprocess, open_mfdataset
+from sdf_xarray import SDFPreprocess, _process_latex_name, open_mfdataset
 
 EXAMPLE_FILES_DIR = pathlib.Path(__file__).parent / "example_files"
 EXAMPLE_MISMATCHED_FILES_DIR = (
@@ -121,18 +121,21 @@ def test_latex_rename_variables():
         preprocess=SDFPreprocess(),
         keep_particles=True,
     )
-    assert df["Electric_Field_Ex"].attrs["long_name"] == "Electric Field E$_x$"
-    assert df["Electric_Field_Ey"].attrs["long_name"] == "Electric Field E$_y$"
-    assert df["Electric_Field_Ez"].attrs["long_name"] == "Electric Field E$_z$"
-    assert df["Magnetic_Field_Bx"].attrs["long_name"] == "Magnetic Field B$_x$"
-    assert df["Magnetic_Field_By"].attrs["long_name"] == "Magnetic Field B$_y$"
-    assert df["Magnetic_Field_Bz"].attrs["long_name"] == "Magnetic Field B$_z$"
-    assert df["Current_Jx"].attrs["long_name"] == "Current J$_x$"
-    assert df["Current_Jy"].attrs["long_name"] == "Current J$_y$"
-    assert df["Current_Jz"].attrs["long_name"] == "Current J$_z$"
-    assert df["Particles_Px_Electron"].attrs["long_name"] == "Particles P$_x$ Electron"
-    assert df["Particles_Py_Electron"].attrs["long_name"] == "Particles P$_y$ Electron"
-    assert df["Particles_Pz_Electron"].attrs["long_name"] == "Particles P$_z$ Electron"
+    assert df["Electric_Field_Ex"].attrs["long_name"] == "Electric Field $E_x$"
+    assert df["Electric_Field_Ey"].attrs["long_name"] == "Electric Field $E_y$"
+    assert df["Electric_Field_Ez"].attrs["long_name"] == "Electric Field $E_z$"
+    assert df["Magnetic_Field_Bx"].attrs["long_name"] == "Magnetic Field $B_x$"
+    assert df["Magnetic_Field_By"].attrs["long_name"] == "Magnetic Field $B_y$"
+    assert df["Magnetic_Field_Bz"].attrs["long_name"] == "Magnetic Field $B_z$"
+    assert df["Current_Jx"].attrs["long_name"] == "Current $J_x$"
+    assert df["Current_Jy"].attrs["long_name"] == "Current $J_y$"
+    assert df["Current_Jz"].attrs["long_name"] == "Current $J_z$"
+    assert df["Particles_Px_Electron"].attrs["long_name"] == "Particles $P_x$ Electron"
+    assert df["Particles_Py_Electron"].attrs["long_name"] == "Particles $P_y$ Electron"
+    assert df["Particles_Pz_Electron"].attrs["long_name"] == "Particles $P_z$ Electron"
+
+    assert _process_latex_name("Example") == "Example"
+    assert _process_latex_name("PxTest") == "PxTest"
 
 
 def test_arrays_with_no_grids():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -137,6 +137,15 @@ def test_latex_rename_variables():
     assert _process_latex_name("Example") == "Example"
     assert _process_latex_name("PxTest") == "PxTest"
 
+    assert (
+        df["Absorption_Fraction_of_Laser_Energy_Absorbed"].attrs["long_name"]
+        == "Absorption Fraction of Laser Energy Absorbed"
+    )
+    assert (
+        df["Derived_Average_Particle_Energy"].attrs["long_name"]
+        == "Derived Average Particle Energy"
+    )
+
 
 def test_arrays_with_no_grids():
     with xr.open_dataset(EXAMPLE_ARRAYS_DIR / "0001.sdf") as df:


### PR DESCRIPTION
Change all `long_name` attributes to use spaces instead of underscores with Title Case

Add LaTeX detection of variables that contain the following prefixes and suffixes:
```python
prefixes = ["E", "B", "J", "P"]
suffixes = ["x", "y", "z"]
```
It will convert from `Electric Field Ex` to `Electric Field E$_x$`
It will only convert to latex if there are spaces before and after OR if there is a space before. This is to ensure that we don't rename variables that might contain those characters within another word. e.g. `Exponential ...`

Fixes #36 